### PR TITLE
It's not 2 commits, it's 1 commit. The other one was a merge.

### DIFF
--- a/pymarc/record.py
+++ b/pymarc/record.py
@@ -217,7 +217,7 @@ class Record(object):
         # can be found
         for field in self.fields:
             field_data = field.as_marc()
-            if self.force_utf8:
+            if self.leader[9] == 'a' or self.force_utf8:
               field_data = field_data.encode('utf-8')
             fields += field_data
             if field.tag.isdigit():


### PR DESCRIPTION
I changed `record.py` so that output is utf8-encoded only if the record was created with `force_utf8=True`. There's probably a better way to handle it, but I think this is at least better than assuming all data will be utf-8.
