### PR TITLE
Fix for a syntax error and a docstring error

### DIFF
--- a/pymarc/record.py
+++ b/pymarc/record.py
@@ -120,7 +120,7 @@ class Record(object):
 
             subjects = record.get_fields('600', '610', '650') 
 
-        If no tag is passed in to fields() a list of all the fields will be 
+        If no tag is passed in to get_fields() a list of all the fields will be 
         returned.
         """
         if (len(args) == 0):


### PR DESCRIPTION
We try to modify an immutable (leader string) and refer to fields() instead of get_fields() in a docstring in record.py. These commits should fix that.
