### PR TITLE
format_field() in field.py

### DIFF
--- a/pymarc/field.py
+++ b/pymarc/field.py
@@ -179,6 +179,8 @@ class Field(object):
             return self.data
         fielddata = ''
         for subfield in self:
+	    if subfield[0] == '6':
+	    	continue
             if not self.is_subject_field():
                 fielddata += ' %s' % subfield[1]
             else:

--- a/test/field.py
+++ b/test/field.py
@@ -97,9 +97,11 @@ class FieldTest(unittest.TestCase):
         self.assertEqual(self.field.is_subject_field(), False)
         
     def test_format_field(self):
-        self.assertEqual(self.subjectfield.format_field(),
+        self.subjectfield.add_subfield('6', '880-4')
+	self.assertEqual(self.subjectfield.format_field(),
             'Python (Computer program language) -- Poetry.')
-        self.assertEqual(self.field.format_field(), 
+        self.field.add_subfield('6', '880-1')
+	self.assertEqual(self.field.format_field(), 
                 'Huckleberry Finn:  An American Odyssey')
 
     def test_tag_normalize(self):


### PR DESCRIPTION
Hi Ed, 

I made a minor change to the format_field method in field.py that I thought I would share in case it is helpful to others.  

format_filed() will now ignore subfield 6 when called.  This eliminates getting formatted field strings that contain the pointers to 880 fields with foreign scripts.  It was returning stings like "880-01 Fu, Jin, 1956-" or "880-02 Xin Zhongguo xi ju shi".  

I added a subfield 6 in test/field.py to verify that it's doing what I intended.    

Thanks for your work on the library.  I use it often.   

Ted Lawless  
