### PR TITLE
New methods for adding fields in grouped/ordered mode

### DIFF
--- a/pymarc/record.py
+++ b/pymarc/record.py
@@ -155,6 +155,56 @@ class Record(object):
         """
         self.fields.extend(fields)
 
+    def add_grouped_field(self, *fields):
+        """
+        add_grouped_field() will add pymarc.Field objects to a Record object,
+        attempting to maintain a loose numeric order per the MARC standard for
+        "Organization of the record" (http://www.loc.gov/marc/96principl.html)
+        Optionally you can pass in multiple fields.
+        """
+        for f in fields:
+            if len(self.fields) == 0 or not f.tag.isdigit():
+                self.fields.append(f)
+                continue 
+            self._sort_fields(f, 'grouped')
+
+    def add_ordered_field(self, *fields):
+        """
+        add_ordered_field() will add pymarc.Field objects to a Record object,
+        attempting to maintain a strict numeric order.
+        Optionally you can pass in multiple fields.
+        """
+        for f in fields:
+            if len(self.fields) == 0 or not f.tag.isdigit():
+                self.fields.append(f)
+                continue 
+            self._sort_fields(f, 'ordered')
+
+    def _sort_fields(self, field, mode):
+        if mode == 'grouped':
+            tag = int(field.tag[0])
+        else:
+            tag = int(field.tag)
+
+        i, last_tag = 0, 0
+        for selff in self.fields:
+            i += 1
+            if not selff.tag.isdigit():
+                self.fields.insert(i - 1, field)
+                break
+
+            if mode == 'grouped':
+                last_tag = int(selff.tag[0])
+            else:
+                last_tag = int(selff.tag)
+
+            if last_tag > tag:
+                self.fields.insert(i - 1, field)
+                break
+            if len(self.fields) == i:
+                self.fields.append(field)
+                break
+
     def remove_field(self, *fields):
         """
         remove_field() will remove one or more pymarc.Field objects from

--- a/test.py
+++ b/test.py
@@ -3,6 +3,7 @@ from test import record
 from test import field
 from test import reader 
 from test import encode
+from test import ordered_fields
 from test import writer
 from test import marc8
 from test import xml_test
@@ -15,6 +16,7 @@ def suite():
     test_suite.addTest(field.suite())
     test_suite.addTest(reader.suite())
     test_suite.addTest(encode.suite())
+    test_suite.addTest(ordered_fields.suite())
     test_suite.addTest(writer.suite())
     test_suite.addTest(marc8.suite())
     test_suite.addTest(xml_test.suite())

--- a/test/ordered_fields.py
+++ b/test/ordered_fields.py
@@ -1,0 +1,49 @@
+import unittest
+import pymarc
+import os
+
+class OrderedFieldsTest(unittest.TestCase):
+
+    def test_add_ordered_fields(self):
+
+        record = pymarc.Record()
+        for tag in ('999', '888', '111', 'abc', '666', '988', '998'):
+            field = pymarc.Field(tag, ['0', '0'], ['a', 'foo'])
+            record.add_ordered_field(field)
+
+        # ensure all numeric fields are in strict order
+        ordered = True
+        last_tag = 0;
+        for field in record:
+            if not field.tag.isdigit():
+                continue
+            curr_tag = int(field.tag)
+            if last_tag > curr_tag:
+                ordered = False
+            last_tag = curr_tag
+
+        self.assertTrue(ordered, "Fields are not strictly ordered numerically")
+
+    def test_add_grouped_fields(self):
+        record = pymarc.Record()
+        for tag in ('999', '888', '111', 'abc', '666', '988', '998'):
+            field = pymarc.Field(tag, ['0', '0'], ['a', 'foo'])
+            record.add_grouped_field(field)
+
+        # ensure all numeric fields are in grouped order
+        grouped = list()
+        for field in record:
+            if not field.tag.isdigit():
+                continue
+            grouped.append(field.tag)
+
+        exp = ['111', '666', '888', '999', '988', '998']
+
+        self.assertEqual(grouped, exp, "Fields are not grouped numerically")
+           
+def suite():
+    test_suite = unittest.makeSuite(OrderedFieldsTest, 'test')
+    return test_suite
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- add_ordered_fields(*fields)
  Adds one or more fields in strictly numeric order. For example, given
  a record containing a 100, 260, and 650 field in that order, a 245 field
  would be inserted between the 100 and 260 fields.
- add_grouped_fields(*fields)
  Adds one or more fields in grouped numeric order, with new fields being
  added at the end of their respective group. For example, given a record
  containing a 100, 260, and 650 field in that order, a 245 field would be
  inserted between the 260 and 650 fields. This behaviour hews closer to
  the MARC standard for organization of records per
  http://www.loc.gov/marc/96principl.html#five

Fields with alphanumeric tags simply get appended to the record.

Signed-off-by: Dan Scott dan@coffeecode.net
