### PR TITLE
UTF8 encoding when writing out records with force_utf8

### DIFF
--- a/pymarc/record.py
+++ b/pymarc/record.py
@@ -355,7 +355,10 @@ class Record(object):
             (record_length, self.leader[5:12], base_address, self.leader[17:])
         
         # return the encoded record
-        return self.leader + directory + fields 
+        if self.leader[9] == 'a' or self.force_utf8:
+            return self.leader.encode('utf-8') + directory.encode('utf-8') + fields
+        else:
+            return self.leader + directory + fields
 
     # alias for backwards compatability
     as_marc21 = as_marc

--- a/test.py
+++ b/test.py
@@ -8,6 +8,7 @@ from test import writer
 from test import marc8
 from test import xml_test
 from test import json_test
+from test import utf8_test
 
 
 def suite():
@@ -21,6 +22,7 @@ def suite():
     test_suite.addTest(marc8.suite())
     test_suite.addTest(xml_test.suite())
     test_suite.addTest(json_test.suite())
+    test_suite.addTest(utf8_test.suite())
     return test_suite
 
 runner = unittest.TextTestRunner()

--- a/test/utf8.xml
+++ b/test/utf8.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+            <marc:collection xmlns:marc="http://www.loc.gov/MARC21/slim" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/MARC21/slim http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd"><marc:record xmlns:marc="http://www.loc.gov/MARC21/slim">
+  <marc:leader>00640njm a2200205uu 4500</marc:leader>
+  <marc:controlfield tag="001">ASP925318/clmu</marc:controlfield>
+  <marc:controlfield tag="008">100813s9999    xx ||nn s|||||||||||||| d</marc:controlfield>
+  <marc:datafield tag="245" ind1="0" ind2="0">
+    <marc:subfield code="a">Zen Classics</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="246" ind1="1" ind2="0">
+    <marc:subfield code="a">Wilfried Hiller: Book of Stars</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="260" ind1=" " ind2=" ">
+    <marc:subfield code="b">Virgin Classics</marc:subfield>
+    <marc:subfield code="c">03 Nov 2008</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="306" ind1=" " ind2=" ">
+    <marc:subfield code="a">18 minutes</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="505" ind1="0" ind2="0">
+    <marc:subfield code="t">Préludes</marc:subfield>
+  </marc:datafield>
+  <marc:datafield tag="856" ind1="4" ind2="0">
+    <marc:subfield code="u">http://www.aspresolver.com/aspresolver.asp?CLMU;925318</marc:subfield>
+  </marc:datafield>
+</marc:record></marc:collection>

--- a/test/utf8_test.py
+++ b/test/utf8_test.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*- 
+
+import unittest
+import pymarc
+import os
+
+class MARCUnicodeTest(unittest.TestCase):
+
+    def test_read_utf8(self):
+        self.field_count = 0
+
+        def process_xml(record):
+            for field in record.get_fields():
+                self.field_count += 1
+            
+        pymarc.map_xml(process_xml, 'test/utf8.xml')
+        self.assertEqual(self.field_count, 8)
+
+    def test_copy_utf8(self):
+        writer = pymarc.MARCWriter(open('test/write-utf8-test.dat', 'w'))
+        new_record = pymarc.Record(to_unicode=True, force_utf8=True)
+        def process_xml(record):
+            new_record.leader = record.leader
+
+            for field in record.get_fields():
+                new_record.add_field(field)
+            
+        pymarc.map_xml(process_xml, 'test/utf8.xml')
+
+        try:
+            writer.write(new_record)
+            writer.close()
+        
+        finally:
+            # remove it
+            os.remove('test/write-utf8-test.dat')
+        
+def suite():
+    test_suite = unittest.makeSuite(MARCUnicodeTest, 'test')
+    return test_suite
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
strings get concatenated with utf-8 encoded data when force_utf8 is in
effect, or LDR09 = a, and that breaks writing out MARC records that
contain Unicode.

Signed-off-by: Dan Scott dan@coffeecode.net
