### PR TITLE
fixes #30; follow MARC-to-JSON proposal

### DIFF
--- a/pymarc/record.py
+++ b/pymarc/record.py
@@ -365,24 +365,28 @@ class Record(object):
 
     def as_dict(self):
         """
-        Turn a MARC record into a dict, which is used for ``as_json``.
+        Turn a MARC record into a dictionary, which is used for ``as_json``.
         """
-        _dict = {}
-        _dict['leader'] = self.leader
-        _dict['fields'] = {}
+        record = {}
+        record['leader'] = self.leader
+        record['fields'] = []
         for field in self:
-            if hasattr(field, 'subfields'):
-                _dict['fields'][field.tag] = {}
-                _dict['fields'][field.tag]['indicators'] = field.indicators
-                _dict['fields'][field.tag]['subfields'] = dict(
-                    izip_longest(*[iter(field.subfields)] * 2))
+            if field.is_control_field():
+                record['fields'].append({field.tag: field.data})
             else:
-                _dict['fields'][field.tag] = field.data
-        return _dict
+                fd = {}
+                fd['subfields'] = []
+                fd['ind1'] = field.indicator1
+                fd['ind2'] = field.indicator2
+                for tag, value in izip_longest(*[iter(field.subfields)] * 2):
+                    fd['subfields'].append({tag: value})
+                record['fields'].append({field.tag: fd})
+        return record  # as dict
 
     def as_json(self, **kwargs):
         """
-        Serialize a record as JSON.
+        Serialize a record as JSON according to
+        http://dilettantes.code4lib.org/blog/2010/09/a-proposal-to-serialize-marc-in-json/
         """
         return json.dumps(self.as_dict(), **kwargs)
 

--- a/test/json_test.py
+++ b/test/json_test.py
@@ -8,49 +8,74 @@ try:
 except ImportError:
     import simplejson as json
 
+
 class JsonTest(unittest.TestCase):
 
     def setUp(self):
         self.reader = pymarc.MARCReader(file('test/test.dat'))
         self._record = pymarc.Record()
         field = pymarc.Field(
-            tag = '245',
-            indicators = ['1', '0'],
-            subfields = ['a', 'Python', 'c', 'Guido'])
+            tag='245',
+            indicators=['1', '0'],
+            subfields=['a', 'Python', 'c', 'Guido'])
         self._record.add_field(field)
 
     def test_as_dict_single(self):
         _expected = {
-            'fields': {
-                '245': {
-                    'indicators': ['1', '0'],
-                    'subfields': {'a': 'Python', 'c': 'Guido'}
+            'fields': [
+                {
+                    '245':  {
+                        'ind1': '1',
+                        'ind2': '0',
+                        'subfields': [
+                            {'a': 'Python'},
+                            {'c': 'Guido'}
+                        ]
+                    }
                 }
-            },
+            ],
             'leader': '          22        4500'
         }
         self.assertEqual(_expected, self._record.as_dict())
 
-    def test_as_dict_multiple(self):
-        for record in self.reader:
-            self.assertTrue(dict, record.as_dict().__class__)
-            self.assertTrue('fields' in record.as_dict())
-            self.assertTrue('leader' in record.as_dict())
+    def test_as_json_types(self):
+        rd = self._record.as_dict()
+        self.assertTrue(isinstance(rd, dict))
+        self.assertTrue(isinstance(rd['leader'], basestring))
+        self.assertTrue(isinstance(rd['fields'], list))
+        self.assertTrue(isinstance(rd['fields'][0], dict))
+        self.assertTrue(isinstance(rd['fields'][0], dict))
+        self.assertTrue(isinstance(rd['fields'][0]['245']['ind1'], basestring))
+        self.assertTrue(isinstance(rd['fields'][0]['245']['ind2'], basestring))
+        self.assertTrue(isinstance(rd['fields'][0]['245']['subfields'], list))
+        self.assertTrue(
+            isinstance(rd['fields'][0]['245']['subfields'][0], dict))
+        self.assertTrue(
+            isinstance(rd['fields'][0]['245']['subfields'][0]['a'], basestring))
+        self.assertTrue(
+            isinstance(rd['fields'][0]['245']['subfields'][1]['c'], basestring))
 
     def test_as_json_simple(self):
-        self.assertTrue('leader' in json.loads(self._record.as_json()))
-        self.assertTrue('fields' in json.loads(self._record.as_json()))
-        self.assertTrue('245' in json.loads(self._record.as_json())['fields'])
-        self.assertTrue('indicators' in json.loads(self._record.as_json())['fields']['245'])
-        self.assertTrue('subfields' in json.loads(self._record.as_json())['fields']['245'])
-        self.assertEquals(dict, json.loads(self._record.as_json())['fields']['245'].__class__)
-        self.assertEquals(list, json.loads(self._record.as_json())['fields']['245']['indicators'].__class__)
-        self.assertEquals(dict, json.loads(self._record.as_json())['fields']['245']['subfields'].__class__)
+        record = json.loads(self._record.as_json())
+
+        self.assertTrue('leader' in record)
+        self.assertEquals(record['leader'], '          22        4500')
+
+        self.assertTrue('fields' in record)
+        self.assertTrue('245' in record['fields'][0])
+        self.assertEquals(record['fields'][0]['245'], {
+            u'subfields': [
+                {u'a': u'Python'},
+                {u'c': u'Guido'}
+            ],
+            u'ind2': u'0',
+            u'ind1': u'1'})
 
     def test_as_json_multiple(self):
         for record in self.reader:
             self.assertTrue(basestring in record.as_json().__class__.__bases__)
             self.assertEquals(dict, json.loads(record.as_json()).__class__)
+
 
 def suite():
     test_suite = unittest.makeSuite(JsonTest, 'test')
@@ -58,4 +83,3 @@ def suite():
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
There was a critical bug in the serializer previously, that missed
repeated subfields. This commit updated `record.as_dict` so that it
- serializes a MARC record in JSON according to the format proposed under
  http://dilettantes.code4lib.org/blog/2010/09/a-proposal-to-serialize-marc-in-json/
