### PR TITLE
Fix AttributeError caused by controlfield iteration

### DIFF
--- a/pymarc/field.py
+++ b/pymarc/field.py
@@ -106,6 +106,8 @@ class Field(object):
 
     def next(self):
         "Needed for iteration."
+        if not hasattr(self, 'subfields'):
+            raise StopIteration
         while self.__pos < len(self.subfields):
             subfield = (self.subfields[ self.__pos ],
                 self.subfields[ self.__pos+1 ])

--- a/test/field.py
+++ b/test/field.py
@@ -135,6 +135,12 @@ class FieldTest(unittest.TestCase):
         else:
             self.fail('KeyError not thrown')
 
+    def test_iter_over_controlfield(self):
+        try:
+            l = [subfield for subfield in self.controlfield]
+        except AttributeError, e:
+            self.fail('Error during iteration: %s' % e)
+
     def test_setitem(self):
         self.field['a'] = 'changed'
         self.assertEqual(self.field['a'], 'changed')


### PR DESCRIPTION
This is a quick fix for a bug I just ran into. If you try and iterate over a controlfield, like so
```
controlfield = Field('008'')

for subfield in controlfield:
    ...do stuff...
```
an AttributeError gets thrown, since `next()` tries to access `self.subfields` which is not set in `__init__`. This will show up anytime `get_subfield` is called on a controlfield, so I added an attribute check in the `next` method to catch this before it happens. There's a test case in here as well to make sure everything checks out.