### PR TITLE
default missing ind1 and ind2 to blank

### DIFF
--- a/pymarc/marcxml.py
+++ b/pymarc/marcxml.py
@@ -47,8 +47,8 @@ class XmlHandler(ContentHandler):
             self._field = Field(tag)
         elif element == 'datafield':
             tag = attrs.getValue((None, u'tag'))
-            ind1 = attrs.getValue((None, u'ind1'))
-            ind2 = attrs.getValue((None, u'ind2'))
+            ind1 = attrs.get((None, u'ind1'), u' ')
+            ind2 = attrs.get((None, u'ind2'), u' ')
             self._field = Field(tag, [ind1, ind2])
         elif element == 'subfield':
             self._subfield_code = attrs[(None, 'code')]


### PR DESCRIPTION
I am given library data which contains records like

```
<marc:datafield tag="946" ind1=" " ind2=" ">
    <marc:subfield code="a">No</marc:subfield>
  </marc:datafield>
  <marc:datafield tag="949">
    <marc:subfield code="a">Article</marc:subfield>
  </marc:datafield>
```

(missing `ind1` & `ind2` in 949), which makes `map_xml()` parsing fail with `KeyError: (None, u'ind1')`.

This patch shouldn't hurt when the indicators are present, and prevents parsing from blowing up when they are not, by providing a reasonable default (I hope).
