### PR TITLE
allow pymarc.Record subclasses to be written by MARCWriter

### DIFF
--- a/pymarc/writer.py
+++ b/pymarc/writer.py
@@ -35,7 +35,7 @@ class MARCWriter(Writer):
         """
         Writes a record.
         """
-        if type(record) != Record:
+        if not isinstance(record, Record):
             raise WriteNeedsRecord
         self.file_handle.write(record.as_marc())
 


### PR DESCRIPTION
- `type` demands equality of types, while `isinstance` caters for inheritance

Background: We subclassed `pymarc.Record` to implement some project specific operations. It would be nice, if `MARCWriter` could write those, too.
