### PR TITLE
Added support of shorthand membership testing for records and fields

### DIFF
--- a/pymarc/field.py
+++ b/pymarc/field.py
@@ -84,6 +84,16 @@ class Field(object):
             return subfields[0]
         return None
 
+    def __contains__(self, subfield):
+        """
+        Allows a shorthand test of field membership:
+
+            'a' in field
+
+        """
+        subfields = self.get_subfields(subfield)
+        return len(subfields) > 0
+
     def __setitem__(self, code, value):
         """
         Set the values of the subfield code in a field:

--- a/pymarc/record.py
+++ b/pymarc/record.py
@@ -138,6 +138,16 @@ class Record(object):
             return fields[0]
         return None
 
+    def __contains__(self, tag):
+        """
+        Allows a shorthand test of tag membership:
+
+            '245' in record
+
+        """
+        fields = self.get_fields(tag)
+        return len(fields) > 0
+
     def __iter__(self):
         self.__pos = 0
         return self

--- a/test/field.py
+++ b/test/field.py
@@ -63,6 +63,10 @@ class FieldTest(unittest.TestCase):
     def test_encode(self):
         self.field.as_marc()
 
+    def test_membership(self):
+        self.assertTrue('a' in self.field)
+        self.assertFalse('zzz' in self.field)
+
     def test_iterator(self):
         string = ""
         for subfield in self.field:

--- a/test/record.py
+++ b/test/record.py
@@ -44,6 +44,16 @@ class RecordTest(unittest.TestCase):
         self.assertEqual(record['245'], title, 'short access')
         self.assertEqual(record['999'], None, 'short access with no field')
 
+    def test_membership(self):
+        record = Record()
+        title = Field(
+            tag = '245',
+            indicators = ['1', '0'],
+            subfields = ['a', 'Python', 'c', 'Guido'])
+        record.add_field(title)
+        self.assertTrue('245' in record)
+        self.assertFalse('999' in record)
+
     def test_field_not_found(self):
         record = Record()
         self.assertEquals(len(record.fields), 0)


### PR DESCRIPTION
Pymarc supports shorthand notation (eg `record['245']`) for accessing tags and I expected being able to do membership testing following the equivalent convention (`'245' in record`).

I've added support for `__contains__` to both records and fields and added the appropriate tests.
