### PR TITLE
Update setuptools for module refactor

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
-include *.py
 prune test

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import pymarc
 version = '3.0.0'
 
 from setuptools import setup
@@ -23,16 +22,14 @@ Programming Language :: Python
 Topic :: Text Processing :: General
 """
 
-import pymarc
-
-setup( 
+setup(
     name = 'pymarc',
     version = version,
     url = 'http://github.com/edsu/pymarc',
     author = 'Ed Summers',
     author_email = 'ehs@pobox.com',
     license = 'http://www.opensource.org/licenses/bsd-license.php',
-    py_modules = ['pymarc'],
+    packages = ['pymarc'],
     install_requires = install_requires,
     description = 'read, write and modify MARC bibliographic data',
     classifiers = filter(None, classifiers.split('\n')),


### PR DESCRIPTION
Currently pymarc 3.0.0 fails to install because setuptools `py_modules`
assumes that each item is a single python file; using `packages` will
trigger the directory install
