### PR TITLE
fixed case when source json record has only one item not wrapped in a list

### DIFF
--- a/pymarc/reader.py
+++ b/pymarc/reader.py
@@ -125,7 +125,7 @@ class JSONReader(Reader):
         self.records =json.load(self.file_handle,strict=False)
 
     def __iter__(self):
-        if hasattr(self.records,'__iter__'):
+        if hasattr(self.records,'__iter__') and not isinstance(self.records, dict):
         	self.iter = iter(self.records)
         else:
         	self.iter = iter([self.records])

--- a/test/json_test.py
+++ b/test/json_test.py
@@ -29,6 +29,14 @@ class JsonReaderTest(unittest.TestCase):
             comp = self.in_json[i]
             self.assertEqual(comp,deserialized)
 
+    def testOneRecord(self):
+        """Tests case when in source json there is only one record not wrapped in list"""
+        data = json.dumps(self.in_json[0])
+        reader = pymarc.JSONReader(data)
+        self.assertEqual([rec.as_dict() for rec in reader][0], self.in_json[0])
+
+
+
 class JsonTest(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
When source record is not a list, but dictionary with single record, it is invalid treated as list of iterable items.
This pull request fixed that case.
