### PR TITLE
Split record_to_xml to create a intermediate function returning ElemenTree node

### DIFF
--- a/pymarc/marcxml.py
+++ b/pymarc/marcxml.py
@@ -128,10 +128,10 @@ def parse_xml_to_array(xml_file, strict=False, normalize_form=None):
     return handler.records
 
 def record_to_xml(record, quiet=False, namespace=False):
-    node = record_to_xmlNode(record, quiet, namespace)
+    node = record_to_xml_node(record, quiet, namespace)
     return ET.tostring(node)
 
-def record_to_xmlNode(record, quiet=False, namespace=False):
+def record_to_xml_node(record, quiet=False, namespace=False):
     """
     converts a record object to a chunk of xml
 


### PR DESCRIPTION
Hi, 
I'm playing with MARC records and generating a MARC21 XML file including XML decorator, collection tag and so.  I call to function record_to_xml and parse back the string to ElementTree node but looking inside function I see it's generating a ElementTree node and  serialize it  just in the return sentence. 

I split  function into two smaller ones, allowing build a xml document very easy without overhead of serialization/deserialization each node. 

Modification keep old funcionality and all test pass OK.

I hope this mod will be useful to you as it's for me.

Regards.
 Manuel.
