### PR TITLE
issue 69: .as_marc() method has side-effects

### DIFF
--- a/pymarc/record.py
+++ b/pymarc/record.py
@@ -364,9 +364,9 @@ class Record(Iterator):
         # the lengths are fixed width and zero padded
         strleader = '%05d%s%05d%s' % \
             (record_length, self.leader[5:12], base_address, self.leader[17:])
-        self.leader = strleader.encode(encoding)
+        leader = strleader.encode(encoding)
         
-        return self.leader + directory + fields
+        return leader + directory + fields
 
     # alias for backwards compatability
     as_marc21 = as_marc

--- a/test/record.py
+++ b/test/record.py
@@ -293,6 +293,12 @@ class RecordTest(unittest.TestCase):
             self.assertEqual(r1['999']['a'], 'foo')
             self.assertEqual(r2['999']['a'], 'bar')
 
+    def test_as_marc_consistency(self):
+        record = Record()
+        leadertype = type(record.leader)
+        record.as_marc()
+        self.assertEqual(leadertype, type(record.leader))
+
 def suite():
     test_suite = unittest.makeSuite(RecordTest, 'test')
     return test_suite 


### PR DESCRIPTION
I have no idea why I modified `self.leader` in this code; it needs to be encoded to be concatenated with the rest of the MARC but there was no reason for this side effect.
