### PR TITLE
Fix for issue #77

### DIFF
--- a/pymarc/record.py
+++ b/pymarc/record.py
@@ -60,8 +60,9 @@ class Record(Iterator):
     """
 
     def __init__(self, data='', to_unicode=True, force_utf8=False,
-        hide_utf8_warnings=False, utf8_handling='strict'):
-        self.leader = (' '*10) + '22' + (' '*8) + '4500'
+        hide_utf8_warnings=False, utf8_handling='strict',
+        leader=' ' * LEADER_LEN):
+        self.leader = leader[0:10] + '22' + leader[12:20] + '4500'
         self.fields = list()
         self.pos = 0
         self.force_utf8 = force_utf8
@@ -188,13 +189,13 @@ class Record(Iterator):
     def remove_fields(self, *tags):
         """
         Remove all the fields with the tags passed to the function:
-            
+
             self.remove_fields('200', '899')
-            
+
         will remove all the fields marked with tags '200' or '899'.
         """
         self.fields[:] = (field for field in self.fields if field.tag not in tags)
-        
+
     def get_fields(self, *args):
         """
         When passed a tag ('245'), get_fields() will return a list of all the

--- a/test/record.py
+++ b/test/record.py
@@ -294,7 +294,8 @@ class RecordTest(unittest.TestCase):
             self.assertEqual(r2['999']['a'], 'bar')
 
     def test_as_marc_with_explicit_leader(self):
-        """ Test setting an explicit leader.
+        """
+        Test setting an explicit leader.
         as_marc() should use the whole leader as set.
         """
         record = Record()
@@ -325,7 +326,9 @@ class RecordTest(unittest.TestCase):
         self.assertEqual(leadertype, type(record.leader))
 
     def test_init_with_no_leader(self):
-        """ Test creating a record object with no leader argument. """
+        """
+        Test creating a Record object with no leader argument.
+        """
         record = Record()
         record.add_field(
             Field(
@@ -337,6 +340,58 @@ class RecordTest(unittest.TestCase):
         self.assertEqual(
             transmission_format_leader,
             b'00067     2200037   4500')
+
+    def test_init_with_no_leader_but_with_force_utf8(self):
+        """
+        Test creating a Record object with no leader argument
+        but with the force_utf8 argument being True.
+        """
+        record = Record(force_utf8 = True)
+        record.add_field(
+            Field(
+                tag = '245',
+                indicators = ['0','1'],
+                subfields = ['a', 'The pragmatic programmer']))
+        transmission_format = record.as_marc()
+        transmission_format_leader = transmission_format[0:24]
+        self.assertEqual(
+            transmission_format_leader,
+            b'00067    a2200037   4500')
+
+    def test_init_with_leader(self):
+        """
+        Test creating a Record with a leader argument.
+        """
+        record = Record(leader='abcdefghijklmnopqrstuvwx')
+        record.add_field(
+            Field(
+                tag = '245',
+                indicators = ['0','1'],
+                subfields = ['a', 'The pragmatic programmer']))
+        transmission_format = record.as_marc()
+        transmission_format_leader = transmission_format[0:24]
+        self.assertEqual(
+            transmission_format_leader,
+            b'00067fghij2200037rst4500')
+
+    def test_init_with_leader_and_force_utf8(self):
+        """
+        Test creating a Record  with a leader argument
+        and with the force_ut8 argument being True.
+        """
+        record = Record(
+            leader = 'abcdefghijklmnopqrstuvwx',
+            force_utf8 = True)
+        record.add_field(
+            Field(
+                tag = '245',
+                indicators = ['0','1'],
+                subfields = ['a', 'The pragmatic programmer']))
+        transmission_format = record.as_marc()
+        transmission_format_leader = transmission_format[0:24]
+        self.assertEqual(
+            transmission_format_leader,
+            b'00067fghia2200037rst4500')
 
 def suite():
     test_suite = unittest.makeSuite(RecordTest, 'test')

--- a/test/record.py
+++ b/test/record.py
@@ -292,12 +292,15 @@ class RecordTest(unittest.TestCase):
             r2.add_field(Field('999', [' ', ' '], subfields=['a', 'bar']))
             self.assertEqual(r1['999']['a'], 'foo')
             self.assertEqual(r2['999']['a'], 'bar')
-        
-    def test_as_marc_leader(self):
+
+    def test_as_marc_with_explicit_leader(self):
+        """ Test setting an explicit leader.
+        as_marc() should use the whole leader as set.
+        """
         record = Record()
         record.add_field(
             Field(
-                tag = '245', 
+                tag = '245',
                 indicators = ['0','1'],
                 subfields = ['a', 'The pragmatic programmer']))
         record.leader = '00067     2200037   4500'
@@ -305,8 +308,7 @@ class RecordTest(unittest.TestCase):
         transmission_format = record.as_marc()
         leader_touched = record.leader
         self.assertTrue(leader_not_touched==leader_touched)
-        
-        
+
     def test_remove_fields(self):
         with open('test/testunimarc.dat', 'rb') as fh:
             record = Record(fh.read(), force_utf8=True)
@@ -315,7 +317,6 @@ class RecordTest(unittest.TestCase):
         record.remove_fields('899', '702')
         self.assertTrue(len(record.get_fields('899'))==0)
         self.assertTrue(len(record.get_fields('702'))==0)
-            
 
     def test_as_marc_consistency(self):
         record = Record()

--- a/test/record.py
+++ b/test/record.py
@@ -324,6 +324,20 @@ class RecordTest(unittest.TestCase):
         record.as_marc()
         self.assertEqual(leadertype, type(record.leader))
 
+    def test_init_with_no_leader(self):
+        """ Test creating a record object with no leader argument. """
+        record = Record()
+        record.add_field(
+            Field(
+                tag = '245',
+                indicators = ['0','1'],
+                subfields = ['a', 'The pragmatic programmer']))
+        transmission_format = record.as_marc()
+        transmission_format_leader = transmission_format[0:24]
+        self.assertEqual(
+            transmission_format_leader,
+            b'00067     2200037   4500')
+
 def suite():
     test_suite = unittest.makeSuite(RecordTest, 'test')
     return test_suite


### PR DESCRIPTION
As per issue #77, adds an optional leader keyword argument to `__init__` of Record.
Added tests to confirm existing behaviour is maintained, for backwards compatibility.
Tested with Python 2.7.10 and 3.4.3.