### PR TITLE
python_2_unicode_compatible is only in six 1.9+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ version = '3.1.1'
 
 from setuptools import setup
 
-install_requires = ['six']
+install_requires = ['six>=1.9.0']
 try:
     import xml.etree
 except ImportError:


### PR DESCRIPTION
requirements.txt specifies minimum version of six, but setup.py doesn't; there have been several people who were hit by missing python_2_unicode_compatible on the mailing list.