### PR TITLE
Don't match on values when deleting subfields

### DIFF
--- a/pymarc/field.py
+++ b/pymarc/field.py
@@ -177,13 +177,11 @@ class Field(Iterator):
 
         If no subfield is found with the specified code None is returned.
         """
-        try:
-            index = self.subfields.index(code)
-            value = self.subfields.pop(index + 1)
-            self.subfields.pop(index)
-            return value
-        except ValueError:
-            return None
+        for index in range(0, len(self.subfields), 2):
+            if self.subfields[index] == code:
+                self.subfields.pop(index)
+                return self.subfields.pop(index)
+        return None
 
     def is_control_field(self):
         """


### PR DESCRIPTION
The current method finds the first item in the subfields list that matches the code to be deleted.  That doesn't work when there is a value that matches that code.