### PR TITLE
specify test file extensions to avoid .pyc in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include test *
+recursive-include test *.py *.dat *.xml *.json *.mrc *.txt *.xml


### PR DESCRIPTION
There was a bug in my previous pull request.

Files with the extension 'pyc' shouldn't be in the pypi tarball.

Sorry about that.