### PR TITLE
Only delete in subfields by matching codes instead of codes and values

### DIFF
--- a/pymarc/field.py
+++ b/pymarc/field.py
@@ -181,9 +181,12 @@ class Field(Iterator):
         """
         try:
             index = self.subfields.index(code)
-            value = self.subfields.pop(index + 1)
-            self.subfields.pop(index)
-            return value
+            if index % 2 == 0:
+                value = self.subfields.pop(index + 1)
+                self.subfields.pop(index)
+                return value
+            else:
+                return None
         except ValueError:
             return None
 

--- a/test/field.py
+++ b/test/field.py
@@ -152,6 +152,12 @@ class FieldTest(unittest.TestCase):
         self.field['a'] = 'changed'
         self.assertEqual(self.field['a'], 'changed')
 
+    def test_delete_subfield_only_by_code(self):
+        self.field.delete_subfield('An American Odyssey')
+        self.assertEqual(self.field['b'], 'An American Odyssey')
+        self.field.delete_subfield('b')
+        self.assertIsNone(self.field['b'])
+
 def suite():
     test_suite = unittest.makeSuite(FieldTest, 'test')
     return test_suite


### PR DESCRIPTION
Previously, if a field __value__ was equal to the provided parameter,
the __value__ got treated as a __code__ and the following (potentially
non-existing) __code__ as a __value__. 

I just realised this is a duplicate of pull request https://github.com/edsu/pymarc/pull/91/commits/26a640058f5e68f9c2164e7f7ee0b4636c95d92e.