### PR TITLE
Issue107

### DIFF
--- a/pymarc/field.py
+++ b/pymarc/field.py
@@ -45,7 +45,7 @@ class Field(Iterator):
         if self.tag < '010' and self.tag.isdigit():
             self.data = data
         else:
-            self.indicator1, self.indicator2 = self.indicators = indicators
+            self.indicators = indicators
             self.subfields = subfields
 
     def __iter__(self):
@@ -242,6 +242,22 @@ class Field(Iterator):
         if self.tag.startswith('6'):
             return True
         return False
+
+    @property
+    def indicator1(self):
+        return self.indicators[0]
+
+    @indicator1.setter
+    def indicator1(self, value):
+        self.indicators[0] = value
+
+    @property
+    def indicator2(self):
+        return self.indicators[1]
+
+    @indicator2.setter
+    def indicator2(self, value):
+        self.indicators[1] = value
 
 
 class RawField(Field):

--- a/test/field.py
+++ b/test/field.py
@@ -158,9 +158,21 @@ class FieldTest(unittest.TestCase):
         self.field.delete_subfield('b')
         self.assertTrue(self.field['b'] is None)
 
+    def test_set_indicators_affects_str(self):
+        self.field.indicators[0] = '9'
+        self.field.indicator2 = '9'
+        self.assertEquals(str(self.field), '=245  99$aHuckleberry Finn: $bAn American Odyssey')
+
+    def test_set_indicators_affects_marc(self):
+        self.field.indicators[0] = '9'
+        self.field.indicator2 = '9'
+        self.assertEquals(self.field.as_marc('utf-8'), b'99\x1faHuckleberry Finn: \x1fbAn American Odyssey\x1e')
+
+
 def suite():
     test_suite = unittest.makeSuite(FieldTest, 'test')
     return test_suite
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Changes Field.indicator1 and Field.indicator2 to properties that use the underlying Field.indicators list. (see issue #107; the previous behavior is that setting the values in the list would result in the str() of a Field showing the new indicator, while only setting the individual attributes would actually affect the MARC output.)