### PR TITLE
Force Python 2.6 and 3.3 back to Trusty; add pypy testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,18 @@
+dist: "xenial"
+
 language: python
 script: python setup.py test
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
-  - "3.4"
-  - "3.5"
-  - "3.6"
 
 matrix:
   include:
+    - python: "2.6"
+      dist: "trusty"
+    - python: "2.7"
+    - python: "3.3"
+      dist: "trusty"
+    - python: "3.4"
+    - python: "3.5"
+    - python: "3.6"
     - python: "3.7"
-      dist: "xenial"
-      sudo: true
+    - python: "pypy"
+    - python: "pypy3"


### PR DESCRIPTION
I have no idea how the main repo is successfully building on Travis now, but my fork is failing horribly because it can't install python 2.6 or 3.3 in the now-default ubuntu Xenial install and presumably even if edsu/pymarc is still defaulting to Trusty for some reason it will eventually get moved to default to Xenial. I can't even find a setting to set the default within Travis.