### PR TITLE
Py38 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,6 @@ matrix:
     - python: "3.5"
     - python: "3.6"
     - python: "3.7"
+    - python: "3.8-dev"
     - python: "pypy"
     - python: "pypy3"

--- a/pymarc/marcxml.py
+++ b/pymarc/marcxml.py
@@ -160,9 +160,9 @@ def record_to_xml_node(record, quiet=False, namespace=False):
             control_field.text = translate(field.data)
         else:
             data_field = ET.SubElement(root, 'datafield')
-            data_field.set('tag', field.tag)
             data_field.set('ind1', field.indicators[0])
             data_field.set('ind2', field.indicators[1])
+            data_field.set('tag', field.tag)
             for subfield in field:
                 data_subfield = ET.SubElement(data_field, 'subfield')
                 data_subfield.set('code', subfield[0])


### PR DESCRIPTION
Total kludge to fix #142 

python 3.8 seems to actually give you XML attributes in the order you add them; previous versions seem to be sorting them? This would add them in the odd order our test is expecting them to be in, and makes the output XML bytewise-consistent between python versions.

(I'm not sure it's reasonable to expect the attributes in a specific order, especially the odd order we do expect where the indicators come after the tag, though. Semantically it's all the same anyway.)