### PR TITLE
ISSN title and number

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,12 +83,12 @@ ANSI Common Lisp /
 
 A `pymarc.Record` object has a few handy methods like `title` for getting at
 bits of a bibliographic record, others include: `author`, `isbn`, `subjects`,
-`location`, `notes`, `physicaldescription`, `publisher`, `pubyear`. But
-really, to work with MARC data you need to understand the numeric field tags
-and subfield codes that are used to designate various bits of information. There
-is a lot more hiding in a MARC record than these methods provide access to.
-For example the `title` method extracts the information from the `245` field,
-subfields `a` and `b`. You can access `245a` like so:
+`location`, `notes`, `physicaldescription`, `publisher`, `pubyear`, `issn`,
+`issn_title`. But really, to work with MARC data you need to understand the
+numeric field tags and subfield codes that are used to designate various bits
+of information. There is a lot more hiding in a MARC record than these methods
+provide access to. For example the `title` method extracts the information from
+ the `245` field, subfields `a` and `b`. You can access `245a` like so:
 
 ```python
 print(record['245']['a'])

--- a/pymarc/record.py
+++ b/pymarc/record.py
@@ -419,7 +419,7 @@ class Record(Iterator):
 
     def title(self):
         """
-        Returns the title of the record (245 $a an $b).
+        Returns the title of the record (245 $a and $b).
         """
         try:
             title = self['245']['a']
@@ -428,6 +428,21 @@ class Record(Iterator):
         if title:
             try:
                 title += " " + self['245']['b']
+            except TypeError:
+                pass
+        return title
+
+    def issn_title(self):
+        """
+        Returns the key title of the record (222 $a and $b).
+        """
+        try:
+            title = self['222']['a']
+        except TypeError:
+            title = None
+        if title:
+            try:
+                title += " " + self['222']['b']
             except TypeError:
                 pass
         return title
@@ -450,6 +465,15 @@ class Record(Iterator):
             # ISBN not set
             pass
         return None
+
+    def issn(self):
+        """
+        Returns the ISSN number [022]['a'] in the record or None
+        """
+        try:
+            return self['022']['a']
+        except TypeError:
+            return None
 
     def sudoc(self):
         """

--- a/test/record.py
+++ b/test/record.py
@@ -150,7 +150,7 @@ class RecordTest(unittest.TestCase):
         record.add_field(Field('020', [' ', ' '], subfields=['a', '006073132X']))
         self.assertEqual(record.isbn(), '006073132X')
 
-   def test_issn(self):
+    def test_issn(self):
         record = Record()
         self.assertEqual(record.issn(), None)
         record.add_field(Field(tag="022", indicators=["0", ""], subfields=["a", "0395-2037"]))

--- a/test/record.py
+++ b/test/record.py
@@ -111,6 +111,23 @@ class RecordTest(unittest.TestCase):
             subfields=['a', "Farghin"]))
         self.assertEqual(record.title(), "Farghin")
 
+    def test_issn_title(self):
+        record = Record()
+        self.assertEqual(record.issn_title(), None)
+        record.add_field(Field('222', ["", ""],
+            subfields=['a', 'Foo :', 'b', 'bar']))
+        self.assertEqual(record.issn_title(), 'Foo : bar')
+
+        record = Record()
+        record.add_field(Field('222', ["", ""],
+            subfields=['a', "Farghin"]))
+        self.assertEqual(record.issn_title(), "Farghin")
+
+        record = Record()
+        record.add_field(Field('222', ["", ""],
+            subfields=['b', "bar"]))
+        self.assertEqual(record.issn_title(), None)
+
     def test_isbn(self):
         record = Record()
         self.assertEqual(record.isbn(), None)
@@ -132,6 +149,12 @@ class RecordTest(unittest.TestCase):
         record = Record()
         record.add_field(Field('020', [' ', ' '], subfields=['a', '006073132X']))
         self.assertEqual(record.isbn(), '006073132X')
+
+   def test_issn(self):
+        record = Record()
+        self.assertEqual(record.issn(), None)
+        record.add_field(Field(tag="022", indicators=["0", ""], subfields=["a", "0395-2037"]))
+        self.assertEqual(record.isbn(), '0395-2037')
 
     def test_multiple_isbn(self):
         with open('test/multi_isbn.dat', 'rb') as fh:

--- a/test/record.py
+++ b/test/record.py
@@ -154,7 +154,7 @@ class RecordTest(unittest.TestCase):
         record = Record()
         self.assertEqual(record.issn(), None)
         record.add_field(Field(tag="022", indicators=["0", ""], subfields=["a", "0395-2037"]))
-        self.assertEqual(record.isbn(), '0395-2037')
+        self.assertEqual(record.issn(), '0395-2037')
 
     def test_multiple_isbn(self):
         with open('test/multi_isbn.dat', 'rb') as fh:


### PR DESCRIPTION
Hi,

This PR adds two new methods to `pymarc.Record` :

- issn : returns the ISSN number stored in 022$a
- issn_title : returns the [key title](https://www.oclc.org/bibformats/en/0xx/022.html) stored in 222$a & $b

Note: I've only added the tests, but not updated the documentation : I just wanted to know your opinion on these before writing it :)