### PR TITLE
Apply license headers

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,7 @@
+Aaron S. Lav <asl2@pobox.com>
+Dan Scott <dan@coffeecode.net> <gitorious@coffeecode.net>
+Eric Hellman <eric@hellman.net>
+Edward Betts <edward@4angle.com> <edwardbetts@gmail.com>
+James Tayson <james.taysom@gmail.com>
+Nick Ruest <ruestn@gmail.com>
+Geoffrey Spear <geoffspear@gmail.com> <speargh@pitt.edu>

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,3 @@
-Copyright 2005-2019 Gabriel Farrell, Mark Matienzo, Geoffrey Spear, Ed Summers
-
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
@@ -20,3 +18,47 @@ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
 CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Copyright for this project is held by its many contributors, including:
+
+Adam Constabaris <ajconsta@ncsu.edu>
+André Nesse <an@macpro.lan>
+Chris Adams <chris@improbable.org>
+Dan Chudnov <dchud@umich.edu>
+Dan Michael O. Heggø <danmichaelo@gmail.com>
+Dan Scott <dan@coffeecode.net>
+David Chouinard <david@davidchouinard.com>
+Ed Hill <hill.charles2@gmail.com>
+Ed Summers <ehs@pobox.com>
+Edward Betts <edward@4angle.com>
+Eric Hellman <eric@hellman.net>
+Gabriel Farrell <gsf747@gmail.com>
+Geoffrey Spear <geoffspear@gmail.com>
+Godmar Back <godmar@gmail.com>
+Helga <cdg013@gmail.com>
+James Tayson <james.taysom@gmail.com>
+Jay Luker <lbjay@reallywow.com>
+Jim Nicholls <jim.nicholls@gmail.com>
+Karol Sikora <me@karolsikora.me>
+Lucas Souza <lucassouzaufpa@gmail.com>
+Mark A. Matienzo <mark@matienzo.org>
+Martin Czygan <martin.czygan@gmail.com>
+Michael B. Klein <mbklein@gmail.com>
+Michael J. Giarlo <leftwing@alumni.rutgers.edu>
+Mikhail Terekhov <termim@gmail.com>
+Nick Ruest <ruestn@gmail.com>
+Pierre Verkest <pverkest@anybox.fr>
+Radim Řehůřek <radimrehurek@seznam.cz>
+Renaud Boyer <rboyer@anybox.fr>
+Robert Marchman <robert.l.marchman@dartmouth.edu>
+Sean Chen <schen@law.duke.edu>
+Simon Hohl <simon.hohl@dainst.org>
+Ted Lawless <tlawless@tuscola.(none)>
+Victor Seva <vseva@dlsi.ua.es>
+Will Earp <will.earp@icloud.com>
+cclauss <cclauss@bluewin.ch>
+cyperus-papyrus <cdg013@gmail.com>
+gitgovdoc <bwebb@gpo.gov>
+mmh <maherma@asdeguiaingenieria.com>
+nemobis <federicoleva@tiscali.it>
+wrCisco <lbjma@tiscali.it>

--- a/apply_headers.py
+++ b/apply_headers.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+
+"""Apply standard license headers and generate contributor list.
+
+Rather than trying to maintain file-level lists of contributors and copyright
+dates, apply a standard license header that points to the LICENSE file for the
+licensing details. And then generate the LICENSE file with a complete list of
+contributors based on the git commit history.
+
+To adjust contributor names or combine email addresses, see .mailmap.
+
+See https://github.com/edsu/pymarc/issues/147 for context.
+"""
+
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
+import pathlib
+import shlex
+import subprocess
+
+
+def get_contributors():
+    """Get a complete list of contributors from `git log`."""
+    # dictionary = add each name only once
+    contribs = {}
+
+    gitargs = shlex.split("git log --use-mailmap --format=short")
+    log = subprocess.run(gitargs, capture_output=True, encoding="utf-8")
+    for line in log.stdout.split("\n"):
+        if line[0 : len("Author: ")] == "Author: ":
+            contribs[line[len("Author: ") :]] = 1
+
+    # Return a list of the contributors
+    return sorted(contribs)
+
+
+def generate_license(contribs):
+    """Generate a BSD-2 license file that lists contributors."""
+    bsd2 = """Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""
+
+    with open("LICENSE", "w") as licensef:
+        licensef.write(bsd2)
+        licensef.write(
+            "Copyright for this project is held by its many contributors, including:\n\n"
+        )
+        for contrib in contribs:
+            licensef.write("{}\n".format(contrib))
+
+
+def apply_headers():
+    """Ensure standard license header is in each Python file."""
+    header = """# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+"""
+
+    path = pathlib.Path(".")
+    for pyfile in list(path.glob("**/*.py")):
+        if str(pyfile) == "docs/source/conf.py" or str(pyfile) == "test/__init__.py":
+            continue
+        with open(pyfile, "r") as reader:
+            contents = reader.read()
+            if contents.find(header) == -1:
+                if str(pyfile) == "test/__init__.py":
+                    # Avoid angering black with a blank line at the end
+                    write_header(pyfile, reader, contents, header)
+                else:
+                    write_header(pyfile, reader, contents, header + "\n")
+
+
+def write_header(pyfile, reader, contents, header):
+    """Rewrite Python source file with the license header."""
+    reader.close()
+    utf8_decl = "# -*- coding: utf-8 -*-\n"
+    with open(pyfile, "w") as writer:
+        if contents.startswith("# __init__.py"):
+            sections = contents.split("\n\n", 1)
+            writer.write(sections[0])
+            writer.write("\n\n")
+            writer.write(header)
+            writer.write(sections[1])
+        elif contents.startswith(utf8_decl):
+            sections = contents.split(utf8_decl, 1)
+            writer.write(utf8_decl)
+            writer.write("\n")
+            writer.write(header)
+            writer.write(sections[1])
+        else:
+            writer.write(header)
+            writer.write(contents)
+
+
+if __name__ == "__main__":
+    generate_license(get_contributors())
+    apply_headers()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,7 +59,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "pymarc"
-copyright = "2005-2020 Gabriel Farrell, Mark Matienzo, Geoffrey Spear, Ed Summers"
+copyright = "Contributors listed in the accompanying LICENSE file"
 author = "Ed Summers"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/pymarc/__init__.py
+++ b/pymarc/__init__.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 from .record import *
 from .field import *
 from .exceptions import *

--- a/pymarc/constants.py
+++ b/pymarc/constants.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 """Constants for pymarc."""
 
 from six import unichr

--- a/pymarc/exceptions.py
+++ b/pymarc/exceptions.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 """Exceptions for pymarc."""
 
 

--- a/pymarc/field.py
+++ b/pymarc/field.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 """The pymarc.field file."""
 
 import logging

--- a/pymarc/leader.py
+++ b/pymarc/leader.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 """The pymarc.leader file."""
 from pymarc.constants import LEADER_LEN
 from pymarc.exceptions import BadLeaderValue, RecordLeaderInvalid

--- a/pymarc/marc8.py
+++ b/pymarc/marc8.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 """Handle MARC-8 files.
 
 see http://www.loc.gov/marc/specifications/speccharmarc8.html

--- a/pymarc/marc8_mapping.py
+++ b/pymarc/marc8_mapping.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 """MARC-8 mapping."""
 
 CHARSET_34 = {  # Extended Arabic

--- a/pymarc/marcjson.py
+++ b/pymarc/marcjson.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 """From JSON to MARC21."""
 
 from pymarc import Field, Record, JSONReader

--- a/pymarc/marcxml.py
+++ b/pymarc/marcxml.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 """From XML to MARC21 and back again."""
 
 import unicodedata

--- a/pymarc/reader.py
+++ b/pymarc/reader.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 """Pymarc Reader."""
 import os
 import sys

--- a/pymarc/record.py
+++ b/pymarc/record.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 """Pymarc Record."""
 import logging
 import re

--- a/pymarc/writer.py
+++ b/pymarc/writer.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 """Pymarc Writer."""
 import pymarc
 from pymarc import Record, WriteNeedsRecord

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 """Pymarc setup."""
 
 from setuptools import setup

--- a/test/test_encode.py
+++ b/test/test_encode.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 import unittest
 
 from pymarc import MARCReader

--- a/test/test_field.py
+++ b/test/test_field.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 import unittest
 import sys
 

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 import unittest
 
 from six import string_types as basestring

--- a/test/test_leader.py
+++ b/test/test_leader.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 """Leader tests."""
 import random
 import string

--- a/test/test_marc8.py
+++ b/test/test_marc8.py
@@ -1,4 +1,11 @@
 # -*- coding: utf-8 -*-
+
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 import os
 from unittest import TestCase, makeSuite
 

--- a/test/test_ordered_fields.py
+++ b/test/test_ordered_fields.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 import unittest
 
 import pymarc

--- a/test/test_reader.py
+++ b/test/test_reader.py
@@ -1,4 +1,11 @@
 # -*- coding: utf-8 -*-
+
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 import re
 import unittest
 

--- a/test/test_record.py
+++ b/test/test_record.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 import unittest
 
 from pymarc.exceptions import BaseAddressInvalid, FieldNotFound, RecordLeaderInvalid

--- a/test/test_utf8.py
+++ b/test/test_utf8.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 import os
 import unittest
 

--- a/test/test_writer.py
+++ b/test/test_writer.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 import os
 import textwrap
 import unittest

--- a/test/test_xml.py
+++ b/test/test_xml.py
@@ -1,3 +1,9 @@
+# This file is part of pymarc. It is subject to the license terms in the
+# LICENSE file found in the top-level directory of this distribution and at
+# https://opensource.org/licenses/BSD-2-Clause. pymarc may be copied, modified,
+# propagated, or distributed according to the terms contained in the LICENSE
+# file.
+
 import pymarc
 import unittest
 


### PR DESCRIPTION
This series of commits creates an apply_headers.py script that generates a LICENSE file containing the complete list of contributors from git history, with an accompanying .mailmap file that allows various git names and email addresses to be given one canonical entry. The script also applies a standard license and copyright header to each Python file directing readers to the LICENSE file for details.

The script should be run as prior to tagging each release to ensure that the list of contributors is kept up to date and that any added files get the standard header.